### PR TITLE
ghc-prim.versions:containers,text,bytestring

### DIFF
--- a/chatter.cabal
+++ b/chatter.cabal
@@ -48,15 +48,16 @@ Library
                      Data.DefaultMap
 
    Build-depends:    base >= 4 && <= 6,
-                     text,
-                     containers,
+                     text >= 0.11.3.0,
+                     containers >= 0.5.3.0,
+                     ghc-prim,
                      safe,
                      random-shuffle,
                      MonadRandom,
                      cereal,
                      fullstop,
                      split,
-                     bytestring,
+                     bytestring >= 0.10.0.0,
                      zlib,
                      filepath
 
@@ -70,9 +71,9 @@ Executable tag
 
    Build-depends:    chatter,
                      filepath,
-                     text,
+                     text >= 0.11.3.0,
                      base       >= 4 && <= 6,
-                     bytestring,
+                     bytestring >= 0.10.0.0,
                      cereal
 
    ghc-options:      -Wall -main-is Tagger -rtsopts
@@ -84,11 +85,11 @@ Executable train
 
    Build-depends:    chatter,
                      filepath,
-                     text,
+                     text >= 0.11.3.0,
                      base       >= 4 && <= 6,
-                     bytestring,
+                     bytestring >= 0.10.0.0,
                      cereal,
-                     containers
+                     containers >= 0.5.3.0
 
    ghc-options:      -Wall -main-is Trainer -rtsopts
 
@@ -99,11 +100,11 @@ Executable eval
 
    Build-depends:    chatter,
                      filepath,
-                     text,
+                     text >= 0.11.3.0,
                      base       >= 4 && <= 6,
-                     bytestring,
+                     bytestring >= 0.10.0.0,
                      cereal,
-                     containers
+                     containers >= 0.5.3.0
 
    ghc-options:      -Wall -main-is Evaluate -rtsopts
 
@@ -118,7 +119,7 @@ Executable bench
    Build-depends:    chatter,
                      criterion,
                      filepath,
-                     text,
+                     text >= 0.11.3.0,
                      base       >= 4 && <= 6,
                      split
 
@@ -142,7 +143,7 @@ test-suite tests
 
    Build-depends:    chatter,
                      base       >= 4 && <= 6,
-                     text,
+                     text >= 0.11.3.0,
                      HUnit,
                      test-framework,
                      test-framework-skip,
@@ -152,6 +153,6 @@ test-suite tests
                      filepath,
                      cereal,
                      quickcheck-instances,
-                     containers
+                     containers >= 0.5.3.0
 
    ghc-options:      -Wall


### PR DESCRIPTION
I am on Fedora 19, running haskell-platform-2012. I needed to specify containers, text and bytestring versions to get it to build. GHC.Generics was also in the hidden ghc-prim.
