### PR TITLE
Bound mbox to avoid conflict from use of lazy Text >= 0.3

### DIFF
--- a/chatter.cabal
+++ b/chatter.cabal
@@ -81,7 +81,7 @@ Library
                      split >= 0.1.2.3,
                      bytestring >= 0.10.0.0,
                      directory,
-                     mbox,
+                     mbox <= 0.2,
                      zlib >= 0.5.4.1,
                      filepath >= 1.3.0.1,
                      ghc-prim,


### PR DESCRIPTION
Starting with 0.3, the `mbox` library uses lazy Text instead of strict, and does not offer a strict alternative. Chatter uses strict Text throughout, so the result is build failure. This PR bounds the version of `mbox` up to 0.2, the highest strict version.