### PR TITLE
Added `DeriveAnyClass` extension for compatibility with GHC 7.10

### DIFF
--- a/src/NLP/ML/AvgPerceptron.hs
+++ b/src/NLP/ML/AvgPerceptron.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE DeriveAnyClass #-}
 -- | Average Perceptron implementation of Part of speech tagging,
 -- adapted for Haskell from this python implementation, which is described on the blog post:
 --
@@ -34,7 +35,7 @@ import GHC.Generics
 import NLP.Types ()
 
 newtype Feature = Feat Text
-    deriving (Read, Show, Eq, Ord, Generic)
+    deriving (Read, Show, Eq, Ord, Generic, NFData)
 
 instance Serialize Feature
 
@@ -45,7 +46,7 @@ instance Serialize Feature
 -- can be defined by the users of the Perceptron (such as custom POS
 -- tag ADTs, or more complex classes).
 newtype Class = Class String
-    deriving (Read, Show, Eq, Ord, Generic)
+    deriving (Read, Show, Eq, Ord, Generic, NFData)
 
 instance Serialize Class
 


### PR DESCRIPTION
chatter wasn't building for me on GHC 7.10.2 because `NLP.ML.AvgPerceptron` wasn't providing an `NFData` instance for `Feature` and `Class`. I added the `DeriveAnyClass` extension and included `NFData` in the `deriving` list for each.

After that it seems to build fine on GHC 7.10.2.

NB. Because of [this issue with regex-tdfa-text](https://github.com/haskell-infra/hackage-trustees/issues/40) I had to install dependencies with `FlexibleContexts` 

    cabal install --dependencies-only --ghc-options=-XFlexibleContexts