### PR TITLE
Remove an orphan instance

### DIFF
--- a/chatter.cabal
+++ b/chatter.cabal
@@ -78,6 +78,7 @@ Library
                      random-shuffle >= 0.0.4,
                      MonadRandom    >= 0.1.2,
                      cereal         >= 0.4.0.1,
+                     cereal-text    >= 0.1 && < 0.2,
                      fullstop       >= 0.1.3.1,
                      bytestring     >= 0.10.0.0,
                      directory,

--- a/src/NLP/Types/Tags.hs
+++ b/src/NLP/Types/Tags.hs
@@ -1,13 +1,12 @@
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE OverloadedStrings #-}
-{-# OPTIONS_GHC -fno-warn-orphans #-}
 module NLP.Types.Tags
 where
 
-import Data.Serialize (Serialize, get, put)
+import Data.Serialize (Serialize)
+import Data.Serialize.Text ()
 import Data.Text (Text)
 import qualified Data.Text as T
-import Data.Text.Encoding (encodeUtf8, decodeUtf8)
 import GHC.Generics
 import Text.Read (readEither)
 
@@ -97,8 +96,3 @@ instance Arbitrary RawTag where
   arbitrary = do
     NonEmpty str <- arbitrary
     return $ RawTag $ T.pack str
-
-instance Serialize Text where
-  put txt = put $ encodeUtf8 txt
-  get     = fmap decodeUtf8 get
-


### PR DESCRIPTION
The Serialize instance for Text is provided by another
package (cereal-text), so duplicating that orphan is problematic when
other transitive dependencies pull in cereal-text.