### PR TITLE
API: add new DefaultMap and TermVector functions

### DIFF
--- a/chatter.cabal
+++ b/chatter.cabal
@@ -232,6 +232,7 @@ test-suite tests
                      tasty,
                      tasty-quickcheck,
                      tasty-hunit,
-                     tasty-ant-xml
+                     tasty-ant-xml,
+                     unordered-containers
 
    ghc-options:      -Wall -auto-all -caf-all

--- a/src/Data/DefaultMap.hs
+++ b/src/Data/DefaultMap.hs
@@ -1,10 +1,13 @@
 {-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE ScopedTypeVariables #-}
 module Data.DefaultMap
 where
 
+import Prelude hiding (lookup)
 import Control.Applicative ((<$>), (<*>))
 import Test.QuickCheck (Arbitrary(..))
 import Control.DeepSeq (NFData)
+import qualified Data.HashSet as S
 import Data.Hashable
 import Data.HashMap.Strict (HashMap)
 import qualified Data.HashMap.Strict as Map
@@ -43,6 +46,14 @@ fromList def entries = DefMap { defDefault = def
 keys :: DefaultMap k a -> [k]
 keys m = Map.keys (defMap m)
 
+-- | Access the non-default values as a list.
+elems :: DefaultMap k a -> [a]
+elems = Map.elems . defMap
+
+-- | Map a function over the values in a map.
+map :: (a -> a) -> DefaultMap k a -> DefaultMap k a
+map f m = m { defMap = f <$> defMap m }
+
 -- | Fold over the values in the map.
 --
 -- Note that this *does* not fold
@@ -50,6 +61,29 @@ keys m = Map.keys (defMap m)
 -- standard `Data.Map.foldl`
 foldl :: (a -> b -> a) -> a -> DefaultMap k b -> a
 foldl fn acc m = Map.foldl' fn acc (defMap m)
+
+-- | Compute the union of two maps using the specified per-value
+-- combination function and the specified new map default value.
+unionWith :: forall v k . (Eq k, Hashable k)
+          => (v -> v -> v)
+          -- ^ Combine values with this function
+          -> v
+          -- ^ The new map's default value
+          -> DefaultMap k v
+          -- ^ The first map to combine
+          -> DefaultMap k v
+          -- ^ The second map to combine
+          -> DefaultMap k v
+unionWith f newDef a b =
+    let allKeys = S.unions [ S.fromList $ Map.keys $ defMap a
+                           , S.fromList $ Map.keys $ defMap b
+                           ]
+        mergeKey :: k -> Map.HashMap k v -> Map.HashMap k v
+        mergeKey k m = Map.insert k (f (lookup k a) (lookup k b)) m
+
+    in DefMap { defDefault = newDef
+              , defMap = S.foldr mergeKey Map.empty allKeys
+              }
 
 instance (Arbitrary k, Arbitrary v, Hashable k, Eq k) => Arbitrary (DefaultMap k v) where
   arbitrary = do

--- a/src/NLP/Similarity/VectorSim.hs
+++ b/src/NLP/Similarity/VectorSim.hs
@@ -89,6 +89,25 @@ cosVec vec1 vec2 = let
   mag = (magnitude vec1 * magnitude vec2)
   in dp / mag
 
+-- | Add two term vectors. When a term is added, its value in each
+-- vector is used (or that vector's default value is used if the term
+-- is absent from the vector). The new term vector resulting from the
+-- addition always uses a default value of zero.
+addVectors :: TermVector -> TermVector -> TermVector
+addVectors = DM.unionWith (+) 0
+
+-- | A "zero vector" term vector (i.e. @addVector v zeroVector = v@).
+zeroVector :: TermVector
+zeroVector = DM.empty 0
+
+-- | Negate a term vector.
+negate :: TermVector -> TermVector
+negate = DM.map ((-1) *)
+
+-- | Add a list of term vectors.
+sum :: [TermVector] -> TermVector
+sum = foldr addVectors zeroVector
+
 -- | Calculate the magnitude of a vector.
 magnitude :: TermVector -> Double
 magnitude v = sqrt $ DM.foldl acc 0 v

--- a/tests/src/Data/DefaultMapTests.hs
+++ b/tests/src/Data/DefaultMapTests.hs
@@ -1,21 +1,50 @@
 module Data.DefaultMapTests where
 
+import Control.Applicative ((<$>))
+import qualified Data.HashSet as S
+import qualified Data.Text as T
 import Test.QuickCheck.Instances ()
 import Test.Tasty (TestTree, testGroup)
 import Test.Tasty.QuickCheck (testProperty)
+import Data.Function (on)
+import Data.List (nubBy)
 
 import Data.Serialize (decode, encode)
 
-import Data.DefaultMap (DefaultMap(..))
+import qualified Data.DefaultMap as DM
 
 tests :: TestTree
 tests = testGroup "NLP.Data.DefaultMapTests"
         [ testGroup "Serialize / Deserialize Tests"
           [ testProperty "DefaultMap round-trips" prop_defMapSerialize
+          , testProperty "DefaultMap elems" prop_elems
+          , testProperty "DefaultMap unionWith" prop_unionWith
+          , testProperty "DefaultMap map" prop_map
           ]
         ]
 
-prop_defMapSerialize :: DefaultMap String String -> Bool
+prop_defMapSerialize :: DM.DefaultMap String String -> Bool
 prop_defMapSerialize c = case (decode . encode) c of
                            Right c' -> c == c'
                            Left _ -> False
+
+prop_elems :: [(T.Text, Int)] -> Bool
+prop_elems pairs =
+    let uPairs = nubBy ((==) `on` fst) pairs
+    in (S.fromList $ snd <$> uPairs) ==
+       (S.fromList $ DM.elems $ DM.fromList 0 uPairs)
+
+prop_map :: [(T.Text, Int)] -> Bool
+prop_map pairs =
+    let uPairs = nubBy ((==) `on` fst) pairs
+        f = (+ 4)
+    in (S.fromList $ f <$> snd <$> uPairs) ==
+       (S.fromList $ DM.elems $ DM.map f $ DM.fromList 0 uPairs)
+
+prop_unionWith :: DM.DefaultMap T.Text Int -> DM.DefaultMap T.Text Int -> Bool
+prop_unionWith a b =
+    let f = (+)
+        result = DM.unionWith f 0 a b
+    in and [ f (DM.lookup k a) (DM.lookup k b) == DM.lookup k result
+           | k <- S.toList $ S.fromList (DM.keys a ++ DM.keys b)
+           ]


### PR DESCRIPTION
- Package: adds unordered-containers dependency to use sets in testing
- DefaultMap: adds elems, map, and unionWith
- TermVector: adds addVectors, zeroVector, negate, and sum
- Adds quickcheck properties for all of the above