### PR TITLE
bump LTS and cereal versions

### DIFF
--- a/chatter.cabal
+++ b/chatter.cabal
@@ -77,7 +77,7 @@ Library
                      containers     >= 0.5.0.0,
                      random-shuffle >= 0.0.4,
                      MonadRandom    >= 0.1.2,
-                     cereal         >= 0.4.0.1 && <= 0.5.4.0,
+                     cereal         >= 0.4.0.1 && <= 0.5.7.0,
                      cereal-text    >= 0.1 && < 0.2,
                      fullstop       >= 0.1.3.1,
                      bytestring     >= 0.10.0.0,
@@ -112,7 +112,7 @@ Executable tagPOS
                      text >= 0.11.3.0,
                      base >= 4.6 && <= 6,
                      bytestring >= 0.10.0.0,
-                     cereal >= 0.4.0.1 && <= 0.5.4.0
+                     cereal >= 0.4.0.1 && <= 0.5.7.0
 
    ghc-options:      -Wall -main-is Tagger -rtsopts
 
@@ -126,7 +126,7 @@ Executable trainPOS
                      text >= 0.11.3.0,
                      base >= 4.6 && <= 6,
                      bytestring >= 0.10.0.0,
-                     cereal >= 0.4.0.1 && <= 0.5.4.0,
+                     cereal >= 0.4.0.1 && <= 0.5.7.0,
                      containers >= 0.5.0.0
 
    ghc-options:      -Wall -main-is POSTrainer -rtsopts
@@ -141,7 +141,7 @@ Executable trainChunker
                      text >= 0.11.3.0,
                      base >= 4.6 && <= 6,
                      bytestring >= 0.10.0.0,
-                     cereal >= 0.4.0.1 && <= 0.5.4.0,
+                     cereal >= 0.4.0.1 && <= 0.5.7.0,
                      containers >= 0.5.0.0
 
    ghc-options:      -Wall -main-is ChunkTrainer -rtsopts
@@ -156,7 +156,7 @@ Executable trainNER
                      text >= 0.11.3.0,
                      base >= 4.6 && <= 6,
                      bytestring >= 0.10.0.0,
-                     cereal >= 0.4.0.1 && <= 0.5.4.0,
+                     cereal >= 0.4.0.1 && <= 0.5.7.0,
                      containers >= 0.5.0.0
 
    ghc-options:      -Wall -main-is NERTrainer -rtsopts
@@ -172,7 +172,7 @@ Executable eval
                      text >= 0.11.3.0,
                      base >= 4.6 && <= 6,
                      bytestring >= 0.10.0.0,
-                     cereal >= 0.4.0.1 && <= 0.5.4.0,
+                     cereal >= 0.4.0.1 && <= 0.5.7.0,
                      containers >= 0.5.0.0
 
    ghc-options:      -Wall -main-is Evaluate -rtsopts
@@ -226,7 +226,7 @@ test-suite tests
                      tokenize,
                      QuickCheck,
                      filepath,
-                     cereal >= 0.4.0.1 && <= 0.5.4.0,
+                     cereal >= 0.4.0.1 && <= 0.5.7.0,
                      quickcheck-instances,
                      containers,
                      tasty,

--- a/stack.yaml
+++ b/stack.yaml
@@ -5,4 +5,4 @@ extra-deps:
 - cereal-text-0.1.0.2
 - fullstop-0.1.4
 - tokenize-0.3.0
-resolver: lts-6.1
+resolver: lts-13.2


### PR DESCRIPTION
From what I can tell, bumping the maximum `cereal` version to 0.5.7.0 is sufficient for fixing the build on LTS-13.