### PR TITLE
Bump cereal version again, this time with a more liberal margin

### DIFF
--- a/chatter.cabal
+++ b/chatter.cabal
@@ -77,7 +77,7 @@ Library
                      containers     >= 0.5.0.0,
                      random-shuffle >= 0.0.4,
                      MonadRandom    >= 0.1.2,
-                     cereal         >= 0.4.0.1 && <= 0.5.7.0,
+                     cereal         >= 0.4.0.1 && < 0.6.0.0,
                      cereal-text    >= 0.1 && < 0.2,
                      fullstop       >= 0.1.3.1,
                      bytestring     >= 0.10.0.0,
@@ -112,7 +112,7 @@ Executable tagPOS
                      text >= 0.11.3.0,
                      base >= 4.6 && <= 6,
                      bytestring >= 0.10.0.0,
-                     cereal >= 0.4.0.1 && <= 0.5.7.0
+                     cereal >= 0.4.0.1 && < 0.6.0.0
 
    ghc-options:      -Wall -main-is Tagger -rtsopts
 
@@ -126,7 +126,7 @@ Executable trainPOS
                      text >= 0.11.3.0,
                      base >= 4.6 && <= 6,
                      bytestring >= 0.10.0.0,
-                     cereal >= 0.4.0.1 && <= 0.5.7.0,
+                     cereal >= 0.4.0.1 && < 0.6.0.0,
                      containers >= 0.5.0.0
 
    ghc-options:      -Wall -main-is POSTrainer -rtsopts
@@ -141,7 +141,7 @@ Executable trainChunker
                      text >= 0.11.3.0,
                      base >= 4.6 && <= 6,
                      bytestring >= 0.10.0.0,
-                     cereal >= 0.4.0.1 && <= 0.5.7.0,
+                     cereal >= 0.4.0.1 && < 0.6.0.0,
                      containers >= 0.5.0.0
 
    ghc-options:      -Wall -main-is ChunkTrainer -rtsopts
@@ -156,7 +156,7 @@ Executable trainNER
                      text >= 0.11.3.0,
                      base >= 4.6 && <= 6,
                      bytestring >= 0.10.0.0,
-                     cereal >= 0.4.0.1 && <= 0.5.7.0,
+                     cereal >= 0.4.0.1 && < 0.6.0.0,
                      containers >= 0.5.0.0
 
    ghc-options:      -Wall -main-is NERTrainer -rtsopts
@@ -172,7 +172,7 @@ Executable eval
                      text >= 0.11.3.0,
                      base >= 4.6 && <= 6,
                      bytestring >= 0.10.0.0,
-                     cereal >= 0.4.0.1 && <= 0.5.7.0,
+                     cereal >= 0.4.0.1 && < 0.6.0.0,
                      containers >= 0.5.0.0
 
    ghc-options:      -Wall -main-is Evaluate -rtsopts
@@ -226,7 +226,7 @@ test-suite tests
                      tokenize,
                      QuickCheck,
                      filepath,
-                     cereal >= 0.4.0.1 && <= 0.5.7.0,
+                     cereal >= 0.4.0.1 && < 0.6.0.0,
                      quickcheck-instances,
                      containers,
                      tasty,


### PR DESCRIPTION
The `cereal` package seems to have a rather quick release cycle and no breaking changes in minor revisions. Thus, to avoid bumping the version on every release, this pull request constrains it to `0.5.*.*`.

Sorry for the inconvenience.