### PR TITLE
Deprecate regex-tdfa-text 

### DIFF
--- a/chatter.cabal
+++ b/chatter.cabal
@@ -90,7 +90,6 @@ Library
                      parsec         >= 3.1.5,
                      transformers,
                      regex-tdfa     >= 1.2.0,
-                     regex-tdfa-text,
                      array,
                      QuickCheck,
                      quickcheck-instances,

--- a/stack.yaml
+++ b/stack.yaml
@@ -5,4 +5,4 @@ extra-deps:
 - cereal-text-0.1.0.2
 - fullstop-0.1.4
 - tokenize-0.3.0
-resolver: lts-13.2
+resolver: lts-16.2


### PR DESCRIPTION
It broke my build with the new resolver and it's not needed anymore as it's incorporated in regex-tdfa