### PR TITLE
Fix test suite compilation if built from sdist

### DIFF
--- a/chatter.cabal
+++ b/chatter.cabal
@@ -77,7 +77,7 @@ Library
                      containers     >= 0.5.0.0,
                      random-shuffle >= 0.0.4,
                      MonadRandom    >= 0.1.2,
-                     cereal         >= 0.4.0.1 && <= 0.5.7.0,
+                     cereal         >= 0.4.0.1 && <= 0.5.9.0,
                      cereal-text    >= 0.1 && < 0.2,
                      fullstop       >= 0.1.3.1,
                      bytestring     >= 0.10.0.0,
@@ -111,7 +111,7 @@ Executable tagPOS
                      text >= 0.11.3.0,
                      base >= 4.6 && <= 6,
                      bytestring >= 0.10.0.0,
-                     cereal >= 0.4.0.1 && <= 0.5.7.0
+                     cereal >= 0.4.0.1 && <= 0.5.9.0
 
    ghc-options:      -Wall -main-is Tagger -rtsopts
 
@@ -125,7 +125,7 @@ Executable trainPOS
                      text >= 0.11.3.0,
                      base >= 4.6 && <= 6,
                      bytestring >= 0.10.0.0,
-                     cereal >= 0.4.0.1 && <= 0.5.7.0,
+                     cereal >= 0.4.0.1 && <= 0.5.9.0,
                      containers >= 0.5.0.0
 
    ghc-options:      -Wall -main-is POSTrainer -rtsopts
@@ -140,7 +140,7 @@ Executable trainChunker
                      text >= 0.11.3.0,
                      base >= 4.6 && <= 6,
                      bytestring >= 0.10.0.0,
-                     cereal >= 0.4.0.1 && <= 0.5.7.0,
+                     cereal >= 0.4.0.1 && <= 0.5.9.0,
                      containers >= 0.5.0.0
 
    ghc-options:      -Wall -main-is ChunkTrainer -rtsopts
@@ -155,7 +155,7 @@ Executable trainNER
                      text >= 0.11.3.0,
                      base >= 4.6 && <= 6,
                      bytestring >= 0.10.0.0,
-                     cereal >= 0.4.0.1 && <= 0.5.7.0,
+                     cereal >= 0.4.0.1 && <= 0.5.9.0,
                      containers >= 0.5.0.0
 
    ghc-options:      -Wall -main-is NERTrainer -rtsopts
@@ -171,7 +171,7 @@ Executable eval
                      text >= 0.11.3.0,
                      base >= 4.6 && <= 6,
                      bytestring >= 0.10.0.0,
-                     cereal >= 0.4.0.1 && <= 0.5.7.0,
+                     cereal >= 0.4.0.1 && <= 0.5.9.0,
                      containers >= 0.5.0.0
 
    ghc-options:      -Wall -main-is Evaluate -rtsopts
@@ -225,7 +225,7 @@ test-suite tests
                      tokenize,
                      QuickCheck,
                      filepath,
-                     cereal >= 0.4.0.1 && <= 0.5.7.0,
+                     cereal >= 0.4.0.1 && <= 0.5.9.0,
                      quickcheck-instances,
                      containers,
                      tasty,

--- a/chatter.cabal
+++ b/chatter.cabal
@@ -207,11 +207,18 @@ test-suite tests
 
    Other-modules:    AvgPerceptronTests
                      BackoffTaggerTests
+                     NLP.Chunk.AvgPerceptronChunkerTests
+                     NLP.Chunk.AvgPerceptronChunkerTests
+                     NLP.Corpora.BrownTests
+                     NLP.Corpora.ConllTests
                      NLP.Similarity.VectorSimTests
                      NLP.POSTests
+                     NLP.POS.LiteralTaggerTests
                      NLP.POS.UnambiguousTaggerTests
                      NLP.Extraction.ParsecTests
                      NLP.TypesTests
+                     NLP.Types.IOBTests
+                     NLP.Types.TreeTests
                      Data.DefaultMapTests
                      Corpora
                      TestUtils


### PR DESCRIPTION
Main point here: if `other-modules` doesn't include all dependencies of the test suite, building the test suite from the sdist will fail as cabal only adds files explicitly mentioned in the cabal file.

Fix #38.