### PR TITLE
Remove duplicate module in chatter.cabal

### DIFF
--- a/chatter.cabal
+++ b/chatter.cabal
@@ -208,7 +208,6 @@ test-suite tests
    Other-modules:    AvgPerceptronTests
                      BackoffTaggerTests
                      NLP.Chunk.AvgPerceptronChunkerTests
-                     NLP.Chunk.AvgPerceptronChunkerTests
                      NLP.Corpora.BrownTests
                      NLP.Corpora.ConllTests
                      NLP.Similarity.VectorSimTests


### PR DESCRIPTION
This prevented me from building chatter with cabal.